### PR TITLE
Replace `edit_traits` with `configure_traits`

### DIFF
--- a/src/gias3/visualisation/fieldvi.py
+++ b/src/gias3/visualisation/fieldvi.py
@@ -282,7 +282,7 @@ class FieldVi(HasTraits):
         self._ipw_picked_points = []
 
     def start(self):
-        self.edit_traits()
+        self.configure_traits()
 
     def addOnCloseCallback(self, callback):
         self.onCloseCallback = callback


### PR DESCRIPTION
Every use of the `FieldVi` `start` method is followed by a call to the Python `input` method. It appears that these calls to `input` are intended to help display the visualisation windows - without them the windows will close immediately after creation. This may have worked previously, but using the most recent versions of the `Mayavi` and `traits` libraries, these calls to `input` are actually blocking the visualisation windows and causing them to hang. The real issue is that `edit_traits` is "designed to run from within a larger application whose GUI is already defined"; whereas the primary entry points into these visualisation windows do not predefine a GUI. `edit_traits` should therefore be replaced with `configure_traits` which is essentially identical to the former except that it is intended to be used as a standalone window.

The usage of `edit_traits` was originally added in [this commit](https://github.com/musculoskeletal/gias2/commit/4823b8931cf8600c2bdfdcbc28dd0345397e4fcd) which was followed by a [commit](https://github.com/musculoskeletal/gias2/commit/3f0e842c7c8998a88bc0e3d8fa43a529597abcf1) to add the calls to `input`. I cannot see any reason for this change. Based on the current implementation, I believe that `configure_traits` would better achieve the intended purpose of this code.

From what I can see the `start` method is only used from within the `gias3.applications` module. Since none of the MAP-Client plugins use this method directly, the conversion should be safe.